### PR TITLE
Add dashboard auth page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState, useRouter } from 'next/navigation';
+import { supabase } from '../../../lib/supabaseClient';
+
+function DashboardPage() {
+  const router = useRouter();
+  const [checking, setChecking] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    const verifySession = async () => {
+      const { data, error } = await supabase.auth.getSession();
+      if (error) {
+        setError(error.message);
+      } else if (!data.session) {
+        router.push('/login');
+      }
+      setChecking(false);
+    };
+
+    verifySession();
+  }, [router]);
+
+  if (checking) {
+    return <main>Checking session...</main>;
+  }
+
+  if (error) {
+    return <main>❌ {error}</main>;
+  }
+
+  return (
+    <main>✅ You are logged in. Welcome to your dashboard.</main>
+  );
+}
+
+export default DashboardPage;


### PR DESCRIPTION
## Summary
- create a dashboard page that checks session with Supabase

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fc571b674832caa4c7f5fda0ec909