### PR TITLE
Implement session persistence and forgot password

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "qbank-platform",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/supabase-js": "^2.49.9",
         "next": "15.3.3",
         "react": "^19.0.0",
@@ -972,6 +973,16 @@
       "integrity": "sha512-zxnHvoMQVqewTJr/W4pKjF0bMGiKJv1WX7bSrkl46Hg0QjESbzBROWK0Wg4RphzSOS5Jiy7eFimmM3UgMrMZbQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-react": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",
+      "integrity": "sha512-5QSaV2CGuhDhd7RlQCoviVEAYsP7XnrFMReOcBazDvVmqSIyjKcDwhLhWvnrxMOq5qjOaA44MHo7wXqDiF0puQ==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.69.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/supabase-js": "^2.49.9",
     "next": "15.3.3",
     "react": "^19.0.0",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '../../../lib/supabaseClient'
 
 function DashboardPage() {
   const router = useRouter()
   const [checking, setChecking] = useState(true)
-  const [error, setError] = useState('')
 
   useEffect(() => {
     const checkUser = async () => {

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '../../../lib/supabaseClient'
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setLoading(true)
+    setMessage('')
+    const { error } = await supabase.auth.resetPasswordForEmail(email)
+    if (error) {
+      setMessage(`❌ ${error.message}`)
+    } else {
+      setMessage('✅ Check your email for the reset link.')
+    }
+    setLoading(false)
+  }
+
+  return (
+    <main style={{ padding: '2rem', maxWidth: '400px', margin: 'auto' }}>
+      <h1>🔑 Forgot Password</h1>
+      <form onSubmit={handleSubmit}>
+        <div style={{ marginBottom: '1rem' }}>
+          <label>Email:</label><br />
+          <input
+            type='email'
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder='you@example.com'
+            style={{ width: '100%', padding: '0.5rem' }}
+            disabled={loading}
+          />
+        </div>
+        <button
+          type='submit'
+          disabled={loading}
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: loading ? '#ccc' : '#0070f3',
+            color: '#fff',
+            border: 'none',
+            cursor: loading ? 'not-allowed' : 'pointer',
+          }}
+        >
+          {loading ? 'Sending...' : 'Send reset link'}
+        </button>
+      </form>
+      {message && (
+        <p style={{ marginTop: '1rem', fontWeight: 'bold' }}>{message}</p>
+      )}
+    </main>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,16 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+import AuthProvider from "../components/AuthProvider";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,10 +14,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className="antialiased bg-white text-black">
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -1,16 +1,29 @@
-'use client';
+'use client'
 
-import { useEffect } from 'react';
-import { supabase } from '../../../lib/supabaseClient';
+import { useEffect } from 'react'
+import { supabase } from '../../../lib/supabaseClient'
 
 export default function TestPage() {
   useEffect(() => {
-    supabase
-      .from('nonexistent_table')
-      .select('*')
-      .then(console.log)
-      .then(undefined, console.error);
-  }, []);
+    async function fetchTest() {
+      try {
+        const { data, error } = await supabase
+          .from('nonexistent_table')
+          .select('*')
 
-  return <div>✅ Supabase connection test page</div>;
+        if (error) {
+          console.error(error)
+        } else {
+          console.log(data)
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    }
+
+    fetchTest()
+  }, [])
+
+  return <div>✅ Supabase connection test page</div>
 }
+

--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -9,7 +9,7 @@ export default function TestPage() {
       .from('nonexistent_table')
       .select('*')
       .then(console.log)
-      .catch(console.error);
+      .then(undefined, console.error);
   }, []);
 
   return <div>✅ Supabase connection test page</div>;

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { SessionContextProvider, Session } from '@supabase/auth-helpers-react'
+import { useEffect, useState } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { supabase } from '../../lib/supabaseClient'
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const getSession = async () => {
+      const { data: { session } } = await supabase.auth.getSession()
+      setSession(session)
+    }
+    getSession()
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+    return () => subscription.unsubscribe()
+  }, [])
+
+  useEffect(() => {
+    if (session === undefined) return
+    const protectedRoutes = ['/dashboard']
+    if (!session && protectedRoutes.includes(pathname)) {
+      router.push('/login')
+    }
+  }, [pathname, router, session])
+
+  if (session === undefined) {
+    return <p>Loading session...</p>
+  }
+
+  return (
+    <SessionContextProvider supabaseClient={supabase} initialSession={session}>
+      {children}
+    </SessionContextProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- add @supabase/auth-helpers-react dependency
- wrap the app with an AuthProvider in the root layout
- auto redirect from protected routes when not logged in
- new forgot-password page to send reset links
- use system fonts in layout instead of Google fonts

## Testing
- `npm run build` *(failed: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405b1e57ac832c9aabbde4d8e39ca1