### PR TITLE
Fix async supabase example

### DIFF
--- a/src/app/test/page.tsx
+++ b/src/app/test/page.tsx
@@ -5,11 +5,23 @@ import { supabase } from '../../../lib/supabaseClient';
 
 export default function TestPage() {
   useEffect(() => {
-    supabase
-      .from('nonexistent_table')
-      .select('*')
-      .then(console.log)
-      .catch(console.error);
+    async function fetchTest() {
+      try {
+        const { data, error } = await supabase
+          .from('nonexistent_table')
+          .select('*');
+
+        if (error) {
+          console.error(error);
+        } else {
+          console.log(data);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+
+    fetchTest();
   }, []);
 
   return <div>✅ Supabase connection test page</div>;


### PR DESCRIPTION
## Summary
- refactor Supabase test page to use async/await

## Testing
- `npm run lint` *(fails: 'error' and 'setError' unused in dashboard page)*

------
https://chatgpt.com/codex/tasks/task_e_68406a802898832c818b7dbe8663ac1e