### PR TITLE
Fix dashboard session check error state

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,17 @@ function DashboardPage() {
 
   useEffect(() => {
     const checkUser = async () => {
-      const { data: { session } } = await supabase.auth.getSession()
+      const {
+        data: { session },
+        error: sessionError,
+      } = await supabase.auth.getSession()
+
+      if (sessionError) {
+        setError(sessionError.message)
+        setChecking(false)
+        return
+      }
+
       if (!session) {
         router.push('/login')
       } else {
@@ -22,6 +32,7 @@ function DashboardPage() {
   }, [router])
 
   if (checking) return <p>Loading...</p>
+  if (error) return <p style={{ color: 'red' }}>❌ {error}</p>
   return <p>✅ You are logged in. Welcome to your dashboard.</p>
 }
 


### PR DESCRIPTION
## Summary
- use `setError` when validating the dashboard session
- display the error message in the dashboard UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68406a7e1cec832cb5fd7cdc9c312d55