### PR TITLE
Remove Geist font note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- eliminate paragraph about automatic Geist font optimization

## Testing
- `npm run lint` *(fails: 'error' and 'setError' unused)*

------
https://chatgpt.com/codex/tasks/task_e_68406a72ffb4832cbac34e77f49959e8