### PR TITLE
Implement logout button in dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,15 @@ function DashboardPage() {
   const [checking, setChecking] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
+  const handleLogout = async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      setError(error.message)
+      return
+    }
+    router.push('/login')
+  }
+
   useEffect(() => {
     const checkUser = async () => {
       const {
@@ -33,7 +42,25 @@ function DashboardPage() {
 
   if (checking) return <p>Loading...</p>
   if (error) return <p style={{ color: 'red' }}>❌ {error}</p>
-  return <p>✅ You are logged in. Welcome to your dashboard.</p>
+  return (
+    <div>
+      <p>✅ You are logged in. Welcome to your dashboard.</p>
+      <button
+        onClick={handleLogout}
+        style={{
+          marginTop: '1rem',
+          padding: '0.5rem 1rem',
+          backgroundColor: '#ef4444',
+          color: '#fff',
+          border: 'none',
+          borderRadius: '4px',
+          cursor: 'pointer',
+        }}
+      >
+        Logout
+      </button>
+    </div>
+  )
 }
 
 export default DashboardPage


### PR DESCRIPTION
## Summary
- add sign-out logic and button to the dashboard page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e2881384832ca62bef72354d6a80