### PR TITLE
Add dashboard features and profile page

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,16 +1,55 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Sidebar from '../../components/Sidebar'
 import TopNav from '../../components/TopNav'
+import Card from '../../components/Card'
 
 export default function DashboardPage() {
+  const [streak, setStreak] = useState(0)
+  const router = useRouter()
+
+  useEffect(() => {
+    const lastDate = typeof window !== 'undefined' ? localStorage.getItem('lastQuizDate') : null
+    const count = typeof window !== 'undefined' ? parseInt(localStorage.getItem('streakCount') || '0', 10) : 0
+    if (lastDate) {
+      const last = new Date(lastDate)
+      const now = new Date()
+      if (now.getTime() - last.getTime() > 24 * 60 * 60 * 1000) {
+        localStorage.setItem('streakCount', '0')
+        setStreak(0)
+      } else {
+        setStreak(count)
+      }
+    } else {
+      setStreak(count)
+    }
+  }, [])
+
+  const startNewQuiz = () => {
+    router.push('/quiz')
+  }
+
   return (
     <div className="flex flex-col sm:flex-row min-h-screen">
       <Sidebar />
       <div className="flex flex-col flex-1">
         <TopNav />
-        <main className="flex-1 p-4">
+        <main className="flex-1 p-4 space-y-4">
           <p>✅ You are logged in. Welcome to your dashboard.</p>
+          <p>🔥 Streak: {streak} days</p>
+          <Card>
+            <h2 className="font-semibold mb-2">Recent Performance</h2>
+            <p>Last Quiz Score: --</p>
+            <p>Date: --</p>
+          </Card>
+          <button
+            onClick={startNewQuiz}
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+          >
+            Start New Quiz
+          </button>
         </main>
       </div>
     </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from '@supabase/auth-helpers-react'
+import { supabase } from '../../../lib/supabaseClient'
+import Sidebar from '../../components/Sidebar'
+import TopNav from '../../components/TopNav'
+import Card from '../../components/Card'
+
+export default function ProfilePage() {
+  const session = useSession()
+  const [name, setName] = useState('')
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (session) {
+      setName((session.user.user_metadata as any)?.full_name || '')
+    }
+  }, [session])
+
+  const handleSave = async () => {
+    setLoading(true)
+    setMessage('')
+    const { error } = await supabase.auth.updateUser({ data: { full_name: name } })
+    if (error) {
+      setMessage(`❌ ${error.message}`)
+    } else {
+      setMessage('✅ Saved changes.')
+    }
+    setLoading(false)
+  }
+
+  if (!session) {
+    return <p>Loading...</p>
+  }
+
+  return (
+    <div className="flex flex-col sm:flex-row min-h-screen">
+      <Sidebar />
+      <div className="flex flex-col flex-1">
+        <TopNav />
+        <main className="flex-1 p-4">
+          <Card className="max-w-md">
+            <h1 className="text-lg font-semibold mb-4">Profile</h1>
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-1">Display Name</label>
+              <input
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                className="border px-2 py-1 rounded w-full"
+              />
+            </div>
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-1">Email</label>
+              <input
+                type="email"
+                value={session.user.email}
+                disabled
+                className="border px-2 py-1 rounded w-full bg-gray-100 cursor-not-allowed"
+              />
+            </div>
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+            >
+              {loading ? 'Saving...' : 'Save Changes'}
+            </button>
+            {message && <p className="mt-2">{message}</p>}
+          </Card>
+        </main>
+      </div>
+    </div>
+  )
+}

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function QuizPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-lg font-semibold">Quiz coming soon...</h1>
+    </main>
+  )
+}

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -24,7 +24,7 @@ export default function AuthProvider({ children }: { children: React.ReactNode }
 
   useEffect(() => {
     if (session === undefined) return
-    const protectedRoutes = ['/dashboard']
+    const protectedRoutes = ['/dashboard', '/profile']
     if (!session && protectedRoutes.includes(pathname)) {
       router.push('/login')
     }

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+export default function Card({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div className={`border rounded shadow p-4 bg-white ${className || ''}`.trim()}>
+      {children}
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,14 +1,16 @@
 'use client'
 
+import Link from 'next/link'
+
 export default function Sidebar() {
   return (
     <aside className="bg-gray-100 w-full sm:w-64 p-4 space-y-2">
       <nav>
         <ul className="space-y-2">
           <li>
-            <a href="#" className="block px-2 py-1 rounded hover:bg-gray-200">
+            <Link href="/dashboard" className="block px-2 py-1 rounded hover:bg-gray-200">
               Home
-            </a>
+            </Link>
           </li>
           <li>
             <a href="#" className="block px-2 py-1 rounded hover:bg-gray-200">
@@ -16,9 +18,9 @@ export default function Sidebar() {
             </a>
           </li>
           <li>
-            <a href="#" className="block px-2 py-1 rounded hover:bg-gray-200">
+            <Link href="/profile" className="block px-2 py-1 rounded hover:bg-gray-200">
               Profile
-            </a>
+            </Link>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Summary
- create reusable `Card` component
- build dashboard features: streak tracker, recent performance placeholder, start quiz button
- add profile page to update display name
- include placeholder quiz route
- update sidebar links and protect `/profile` route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ee5c0354832ca16552aad82535b4