### PR TITLE
Add basic quiz functionality

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -7,6 +7,10 @@ import Sidebar from '../../components/Sidebar'
 import TopNav from '../../components/TopNav'
 import Card from '../../components/Card'
 
+interface UserMetadata {
+  full_name?: string
+}
+
 export default function ProfilePage() {
   const session = useSession()
   const [name, setName] = useState('')
@@ -15,7 +19,8 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (session) {
-      setName((session.user.user_metadata as any)?.full_name || '')
+      const meta = session.user.user_metadata as UserMetadata
+      setName(meta?.full_name || '')
     }
   }, [session])
 

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -1,9 +1,73 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import QuestionCard from '../../components/QuestionCard'
+import { supabase } from '../../../lib/supabaseClient'
+
+interface Question {
+  id: string
+  question_text: string
+  option_a: string
+  option_b: string
+  option_c: string
+  option_d: string
+  correct_option: string
+  explanation?: string | null
+}
+
 export default function QuizPage() {
+  const [questions, setQuestions] = useState<Question[]>([])
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [loading, setLoading] = useState(true)
+
+  // load saved answers from localStorage
+  useEffect(() => {
+    const saved = localStorage.getItem('quizAnswers')
+    if (saved) {
+      setAnswers(JSON.parse(saved))
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem('quizAnswers', JSON.stringify(answers))
+  }, [answers])
+
+  useEffect(() => {
+    async function loadQuestions() {
+      setLoading(true)
+      const { data, error } = await supabase
+        .from('questions')
+        .select('*')
+        .limit(10)
+
+      if (error) {
+        console.error('Error fetching questions', error.message)
+      } else if (data) {
+        setQuestions(data as Question[])
+      }
+      setLoading(false)
+    }
+
+    loadQuestions()
+  }, [])
+
+  const handleSelect = (id: string, option: string) => {
+    setAnswers(prev => ({ ...prev, [id]: option }))
+  }
+
   return (
-    <main className="p-4">
-      <h1 className="text-lg font-semibold">Quiz coming soon...</h1>
+    <main className="p-4 space-y-4">
+      <h1 className="text-lg font-semibold">Quiz</h1>
+      {loading && <p>Loading questions...</p>}
+      {questions.map(q => (
+        <QuestionCard
+          key={q.id}
+          question={q}
+          selected={answers[q.id]}
+          onSelect={(opt) => handleSelect(q.id, opt)}
+          showFeedback={!!answers[q.id]}
+        />
+      ))}
     </main>
   )
 }

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+
+type Question = {
+  id: string
+  question_text: string
+  option_a: string
+  option_b: string
+  option_c: string
+  option_d: string
+  correct_option: string
+  explanation?: string | null
+}
+
+interface Props {
+  question: Question
+  selected?: string
+  onSelect: (option: string) => void
+  showFeedback?: boolean
+}
+
+export default function QuestionCard({ question, selected, onSelect, showFeedback }: Props) {
+  const options = [
+    { key: 'option_a', label: question.option_a },
+    { key: 'option_b', label: question.option_b },
+    { key: 'option_c', label: question.option_c },
+    { key: 'option_d', label: question.option_d },
+  ]
+
+  const handleChange = (key: string) => {
+    onSelect(key)
+  }
+
+  return (
+    <div className="border rounded p-4 space-y-2">
+      <p className="font-medium">{question.question_text}</p>
+      {options.map(({ key, label }) => {
+        const isChecked = selected === key
+        let optionStyle = ''
+        if (showFeedback && isChecked) {
+          optionStyle = key === question.correct_option ? 'text-green-600' : 'text-red-600'
+        }
+        return (
+          <label key={key} className={`block ${optionStyle}`}>
+            <input
+              type="radio"
+              name={question.id}
+              checked={isChecked}
+              onChange={() => handleChange(key)}
+              className="mr-2"
+            />
+            {label}
+          </label>
+        )
+      })}
+      {showFeedback && selected && question.explanation && (
+        <p className="mt-2 text-sm text-gray-600">{question.explanation}</p>
+      )}
+    </div>
+  )
+}

--- a/supabase/migrations/202404291200_create_questions.sql
+++ b/supabase/migrations/202404291200_create_questions.sql
@@ -1,0 +1,21 @@
+-- SQL migration for questions table
+create table if not exists public.questions (
+  id uuid primary key default gen_random_uuid(),
+  question_text text not null,
+  option_a text not null,
+  option_b text not null,
+  option_c text not null,
+  option_d text not null,
+  correct_option text not null,
+  topic text not null,
+  difficulty text not null,
+  tags text[],
+  explanation text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.questions enable row level security;
+
+create policy "Allow read for authenticated users" on public.questions
+  for select to authenticated
+  using (true);


### PR DESCRIPTION
## Summary
- add Supabase migration for questions table with RLS
- create `QuestionCard` component
- implement quiz page that fetches questions, shows feedback and saves answers
- fix lint error in Profile page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68423be0cacc832cb18860fc89505165