### PR TITLE
Remove inline styles from auth pages

### DIFF
--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -22,36 +22,31 @@ export default function ForgotPasswordPage() {
   }
 
   return (
-    <main style={{ padding: '2rem', maxWidth: '400px', margin: 'auto' }}>
+    <main className="p-8 max-w-md mx-auto">
       <h1>🔑 Forgot Password</h1>
       <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '1rem' }}>
-          <label>Email:</label><br />
+        <div className="mb-4">
+          <label>Email:</label>
+          <br />
           <input
             type='email'
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder='you@example.com'
-            style={{ width: '100%', padding: '0.5rem' }}
+            className='w-full p-2'
             disabled={loading}
           />
         </div>
         <button
           type='submit'
           disabled={loading}
-          style={{
-            padding: '0.5rem 1rem',
-            backgroundColor: loading ? '#ccc' : '#0070f3',
-            color: '#fff',
-            border: 'none',
-            cursor: loading ? 'not-allowed' : 'pointer',
-          }}
+          className='px-4 py-2 text-white bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed'
         >
           {loading ? 'Sending...' : 'Send reset link'}
         </button>
       </form>
       {message && (
-        <p style={{ marginTop: '1rem', fontWeight: 'bold' }}>{message}</p>
+        <p className='mt-4 font-bold'>{message}</p>
       )}
     </main>
   )

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -31,47 +31,43 @@ function LoginPage() {
   };
 
   return (
-    <main style={{ padding: '2rem', maxWidth: '400px', margin: 'auto' }}>
+    <main className="p-8 max-w-md mx-auto">
       <h1>🔐 Login</h1>
       <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: '1rem' }}>
-          <label>Email:</label><br />
+        <div className="mb-4">
+          <label>Email:</label>
+          <br />
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
-            style={{ width: '100%', padding: '0.5rem' }}
+            className="w-full p-2"
             disabled={loading}
           />
         </div>
-        <div style={{ marginBottom: '1rem' }}>
-          <label>Password:</label><br />
+        <div className="mb-4">
+          <label>Password:</label>
+          <br />
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
-            style={{ width: '100%', padding: '0.5rem' }}
+            className="w-full p-2"
             disabled={loading}
           />
         </div>
         <button
           type="submit"
           disabled={loading}
-          style={{
-            padding: '0.5rem 1rem',
-            backgroundColor: loading ? '#ccc' : '#0070f3',
-            color: '#fff',
-            border: 'none',
-            cursor: loading ? 'not-allowed' : 'pointer',
-          }}
+          className="px-4 py-2 text-white bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
         >
           {loading ? 'Logging in...' : 'Login'}
         </button>
       </form>
       {error && (
-        <p style={{ marginTop: '1rem', color: 'red' }}>{error}</p>
+        <p className="mt-4 text-red-600">{error}</p>
       )}
     </main>
   );

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -33,30 +33,32 @@ export default function SignupPage() {
   };
 
   return (
-    <main style={{ padding: "2rem", maxWidth: "400px", margin: "auto" }}>
+    <main className="p-8 max-w-md mx-auto">
       <h1>📝 Sign up</h1>
 
       <form onSubmit={handleSubmit}>
-        <div style={{ marginBottom: "1rem" }}>
-          <label>Email:</label><br />
+        <div className="mb-4">
+          <label>Email:</label>
+          <br />
           <input
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
-            style={{ width: "100%", padding: "0.5rem" }}
+            className="w-full p-2"
             disabled={loading}
           />
         </div>
 
-        <div style={{ marginBottom: "1rem" }}>
-          <label>Password:</label><br />
+        <div className="mb-4">
+          <label>Password:</label>
+          <br />
           <input
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
-            style={{ width: "100%", padding: "0.5rem" }}
+            className="w-full p-2"
             disabled={loading}
           />
         </div>
@@ -64,20 +66,14 @@ export default function SignupPage() {
         <button
           type="submit"
           disabled={loading}
-          style={{
-            padding: "0.5rem 1rem",
-            backgroundColor: loading ? "#ccc" : "#0070f3",
-            color: "#fff",
-            border: "none",
-            cursor: loading ? "not-allowed" : "pointer",
-          }}
+          className="px-4 py-2 text-white bg-blue-600 disabled:bg-gray-300 disabled:cursor-not-allowed"
         >
           {loading ? "Signing up..." : "Sign Up"}
         </button>
       </form>
 
       {message && (
-        <p style={{ marginTop: "1rem", fontWeight: "bold" }}>{message}</p>
+        <p className="mt-4 font-bold">{message}</p>
       )}
     </main>
   );


### PR DESCRIPTION
## Summary
- refactor signup, login and forgot password pages
- use Tailwind classes instead of inline `style` objects

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68424cfb0a44832cbc0911b6b467ce49