### PR TITLE
Add quiz scoring and answer review

### DIFF
--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -20,6 +20,8 @@ export default function QuizPage() {
   const [questions, setQuestions] = useState<Question[]>([])
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const [score, setScore] = useState(0)
   const session = useSession()
 
   // load saved answers from localStorage
@@ -60,7 +62,17 @@ export default function QuizPage() {
   }, [session])
 
   const handleSelect = (id: string, option: string) => {
-    setAnswers(prev => ({ ...prev, [id]: option }))
+    if (!isSubmitted) {
+      setAnswers(prev => ({ ...prev, [id]: option }))
+    }
+  }
+
+  const handleSubmit = () => {
+    const correct = questions.reduce((acc, q) => {
+      return answers[q.id] === q.correct_option ? acc + 1 : acc
+    }, 0)
+    setScore(correct)
+    setIsSubmitted(true)
   }
 
   return (
@@ -79,9 +91,35 @@ export default function QuizPage() {
             question={q}
             selected={answers[q.id]}
             onSelect={(opt) => handleSelect(q.id, opt)}
-            showFeedback={!!answers[q.id]}
+            showFeedback={isSubmitted}
+            disabled={isSubmitted}
+            isSubmitted={isSubmitted}
           />
         ))}
+        {questions.length > 0 && !isSubmitted && (
+          <button
+            onClick={handleSubmit}
+            className="px-4 py-2 bg-blue-600 text-white rounded"
+          >
+            Submit Quiz
+          </button>
+        )}
+        {isSubmitted && (
+          <div className="space-y-2">
+            <p>
+              You scored {score} out of {questions.length}
+            </p>
+            <p>
+              {score / questions.length >= 0.8 ? 'Great job!' : 'Keep practicing!'}
+            </p>
+            <div className="w-full bg-gray-200 rounded h-4">
+              <div
+                className={`h-4 rounded ${score / questions.length >= 0.8 ? 'bg-green-500' : 'bg-red-500'}`}
+                style={{ width: `${(score / questions.length) * 100}%` }}
+              />
+            </div>
+          </div>
+        )}
       </main>
     )
   )

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -17,9 +17,18 @@ interface Props {
   selected?: string
   onSelect: (option: string) => void
   showFeedback?: boolean
+  disabled?: boolean
+  isSubmitted?: boolean
 }
 
-export default function QuestionCard({ question, selected, onSelect, showFeedback }: Props) {
+export default function QuestionCard({
+  question,
+  selected,
+  onSelect,
+  showFeedback,
+  disabled,
+  isSubmitted,
+}: Props) {
   const options = [
     { key: 'option_a', label: question.option_a },
     { key: 'option_b', label: question.option_b },
@@ -28,7 +37,9 @@ export default function QuestionCard({ question, selected, onSelect, showFeedbac
   ]
 
   const handleChange = (key: string) => {
-    onSelect(key)
+    if (!disabled) {
+      onSelect(key)
+    }
   }
 
   return (
@@ -37,7 +48,13 @@ export default function QuestionCard({ question, selected, onSelect, showFeedbac
       {options.map(({ key, label }) => {
         const isChecked = selected === key
         let optionStyle = ''
-        if (showFeedback && isChecked) {
+        if (isSubmitted) {
+          if (key === question.correct_option) {
+            optionStyle = 'text-green-600'
+          } else if (isChecked) {
+            optionStyle = 'text-red-600'
+          }
+        } else if (showFeedback && isChecked) {
           optionStyle = key === question.correct_option ? 'text-green-600' : 'text-red-600'
         }
         return (
@@ -47,13 +64,14 @@ export default function QuestionCard({ question, selected, onSelect, showFeedbac
               name={question.id}
               checked={isChecked}
               onChange={() => handleChange(key)}
+              disabled={disabled}
               className="mr-2"
             />
             {label}
           </label>
         )
       })}
-      {showFeedback && selected && question.explanation && (
+      {(showFeedback || isSubmitted) && selected && question.explanation && (
         <p className="mt-2 text-sm text-gray-600">{question.explanation}</p>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add `isSubmitted` and `score` state to the quiz page
- allow submitting a quiz and locking in answers
- show results with a success message and progress bar
- update `QuestionCard` to handle disabled state and show correct/incorrect answers

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842e0bf8758832c8503634d833efdbc