### PR TITLE
Add quiz progress bar and visual feedback

### DIFF
--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -111,16 +111,15 @@ export default function QuizPage() {
         {isSubmitted && (
           <div className="space-y-2">
             <p>
-              You scored {score} out of {questions.length}
-            </p>
-            <p>
               {score / questions.length >= 0.8 ? 'Great job!' : 'Keep practicing!'}
             </p>
-            <div className="w-full bg-gray-200 rounded h-4">
+            <div className="w-full bg-gray-200 rounded h-6">
               <div
-                className={`h-4 rounded ${score / questions.length >= 0.8 ? 'bg-green-500' : 'bg-red-500'}`}
+                className={`h-6 rounded flex items-center justify-center text-white text-sm ${score / questions.length >= 0.8 ? 'bg-green-500' : 'bg-red-500'}`}
                 style={{ width: `${(score / questions.length) * 100}%` }}
-              />
+              >
+                {`Score: ${Math.round((score / questions.length) * 100)}% (${score}/${questions.length} correct)`}
+              </div>
             </div>
           </div>
         )}

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -47,18 +47,30 @@ export default function QuestionCard({
       <p className="font-medium">{question.question_text}</p>
       {options.map(({ key, label }) => {
         const isChecked = selected === key
+        const isCorrect = key === question.correct_option
         let optionStyle = ''
         if (isSubmitted) {
-          if (key === question.correct_option) {
+          if (isCorrect) {
             optionStyle = 'text-green-600'
           } else if (isChecked) {
             optionStyle = 'text-red-600'
+          } else {
+            optionStyle = 'text-gray-400'
           }
         } else if (showFeedback && isChecked) {
-          optionStyle = key === question.correct_option ? 'text-green-600' : 'text-red-600'
+          optionStyle = isCorrect ? 'text-green-600' : 'text-red-600'
         }
+
+        const icon = isSubmitted
+          ? isCorrect
+            ? ' ✅'
+            : isChecked
+              ? ' ❌'
+              : ''
+          : ''
+
         return (
-          <label key={key} className={`block ${optionStyle}`}>
+          <label key={key} className={`block ${optionStyle}`.trim()}>
             <input
               type="radio"
               name={question.id}
@@ -68,6 +80,7 @@ export default function QuestionCard({
               className="mr-2"
             />
             {label}
+            {icon}
           </label>
         )
       })}


### PR DESCRIPTION
## Summary
- show congratulatory text with embedded progress bar
- mark correct/incorrect answers with ✅/❌ and grey out the rest

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842e9e238a8832c9d09378130e46f51