### PR TITLE
Improve quiz results UI

### DIFF
--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -109,18 +109,19 @@ export default function QuizPage() {
           </button>
         )}
         {isSubmitted && (
-          <div className="space-y-2">
+          <div className="p-4 border rounded mt-6 space-y-2">
             <p>
               {score / questions.length >= 0.8 ? 'Great job!' : 'Keep practicing!'}
             </p>
-            <div className="w-full bg-gray-200 rounded h-6">
+            <div className="w-full bg-gray-300 h-4 rounded">
               <div
-                className={`h-6 rounded flex items-center justify-center text-white text-sm ${score / questions.length >= 0.8 ? 'bg-green-500' : 'bg-red-500'}`}
+                className={`h-4 rounded transition-all ${score / questions.length >= 0.8 ? 'bg-green-500' : 'bg-red-500'}`}
                 style={{ width: `${(score / questions.length) * 100}%` }}
-              >
-                {`Score: ${Math.round((score / questions.length) * 100)}% (${score}/${questions.length} correct)`}
-              </div>
+              ></div>
             </div>
+            <p className="text-sm mt-2">
+              Score: {score}/{questions.length} ({Math.round((score / questions.length) * 100)}%)
+            </p>
           </div>
         )}
       </main>

--- a/src/components/QuestionCard.tsx
+++ b/src/components/QuestionCard.tsx
@@ -43,8 +43,8 @@ export default function QuestionCard({
   }
 
   return (
-    <div className="border rounded p-4 space-y-2">
-      <p className="font-medium">{question.question_text}</p>
+    <div className="mb-6 p-4 border rounded space-y-2">
+      <p className="text-lg font-semibold mb-2">{question.question_text}</p>
       {options.map(({ key, label }) => {
         const isChecked = selected === key
         const isCorrect = key === question.correct_option
@@ -63,11 +63,11 @@ export default function QuestionCard({
 
         const icon = isSubmitted
           ? isCorrect
-            ? ' ✅'
+            ? <span className="ml-1 text-green-600">✅</span>
             : isChecked
-              ? ' ❌'
-              : ''
-          : ''
+              ? <span className="ml-1 text-red-600">❌</span>
+              : null
+          : null
 
         return (
           <label key={key} className={`block ${optionStyle}`.trim()}>
@@ -77,7 +77,7 @@ export default function QuestionCard({
               checked={isChecked}
               onChange={() => handleChange(key)}
               disabled={disabled}
-              className="mr-2"
+              className={`mr-2 ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
             />
             {label}
             {icon}
@@ -85,7 +85,7 @@ export default function QuestionCard({
         )
       })}
       {(showFeedback || isSubmitted) && selected && question.explanation && (
-        <p className="mt-2 text-sm text-gray-600">{question.explanation}</p>
+        <p className="mt-4 text-sm text-gray-600">{question.explanation}</p>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- style `QuestionCard` layout for cleaner spacing
- color code answer correctness with Tailwind and icons
- revamp results section with progress bar and score text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6842f96d4294832c9fc2f5ed8a0d0164