### PR TITLE
Fix quiz progress bar

### DIFF
--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -81,9 +81,8 @@ export default function QuizPage() {
   }
 
   const totalQuestions = questions.length
-  const scorePercent = totalQuestions
-    ? Math.round((score / totalQuestions) * 100)
-    : 0
+  const correctAnswers = score
+  const scorePercent = Math.round((correctAnswers / totalQuestions) * 100)
 
   return (
     !session ? (
@@ -119,9 +118,9 @@ export default function QuizPage() {
           <div className="p-4 border rounded mt-6 space-y-2">
             <p>{scorePercent >= 80 ? 'Great job!' : 'Keep practicing!'}</p>
             <p className="text-sm mt-2">
-              Score: {score}/{questions.length} ({scorePercent}%)
+              Score: {correctAnswers}/{totalQuestions} correct
             </p>
-            <div className="w-full bg-gray-200 h-4 rounded mt-4">
+            <div className="w-full bg-gray-300 h-4 rounded mt-4">
               <div
                 className={`${
                   scorePercent >= 80 ? 'bg-green-500' : 'bg-red-500'
@@ -129,6 +128,9 @@ export default function QuizPage() {
                 style={{ width: `${scorePercent}%` }}
               />
             </div>
+            <p className="text-sm mt-2">
+              Score: {scorePercent}% ({correctAnswers}/{totalQuestions} correct)
+            </p>
           </div>
         )}
       </main>


### PR DESCRIPTION
## Summary
- compute quiz progress using `correctAnswers`
- show progress bar and score summary after submitting the quiz

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6843526b53d0832c85c6bd9d5e1c33d7