### PR TITLE
Add personalized quiz features

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -31,6 +31,10 @@ export default function DashboardPage() {
     router.push('/quiz')
   }
 
+  const startWeakQuiz = () => {
+    router.push('/quiz?personalized=true')
+  }
+
   return (
     <div className="flex flex-col sm:flex-row min-h-screen">
       <Sidebar />
@@ -49,6 +53,12 @@ export default function DashboardPage() {
             className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
           >
             Start New Quiz
+          </button>
+          <button
+            onClick={startWeakQuiz}
+            className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600"
+          >
+            Practice Weak Areas
           </button>
         </main>
       </div>

--- a/src/app/quiz/page.tsx
+++ b/src/app/quiz/page.tsx
@@ -2,8 +2,10 @@
 
 import { useEffect, useState } from 'react'
 import { useSession } from '@supabase/auth-helpers-react'
+import { useSearchParams } from 'next/navigation'
 import QuestionCard from '../../components/QuestionCard'
 import { supabase } from '../../../lib/supabaseClient'
+import { estimateDifficulty, Difficulty } from '../../../utils/estimateDifficulty'
 
 interface Question {
   id: string
@@ -13,6 +15,8 @@ interface Question {
   option_c: string
   option_d: string
   correct_option: string
+  topic: string
+  difficulty: Difficulty
   explanation?: string | null
 }
 
@@ -23,7 +27,9 @@ export default function QuizPage() {
   const [isSubmitted, setIsSubmitted] = useState(false)
   const [score, setScore] = useState(0)
   const [error, setError] = useState('')
+  const [difficultyFilter, setDifficultyFilter] = useState<'All' | Difficulty>('All')
   const session = useSession()
+  const searchParams = useSearchParams()
 
   // load saved answers from localStorage
   useEffect(() => {
@@ -42,26 +48,64 @@ export default function QuizPage() {
       return
     }
 
-
     async function loadQuestions() {
       setLoading(true)
-      const { data, error: fetchError } = await supabase
-        .from('questions')
-        .select('*')
-        .limit(5)
+
+      const personalized = searchParams.get('personalized') === 'true'
+
+      let questionQuery = supabase.from('questions').select('*')
+      if (difficultyFilter !== 'All') {
+        questionQuery = questionQuery.eq('difficulty', difficultyFilter)
+      }
+
+      if (personalized) {
+        const { data: weakTopics, error: weakErr } = await supabase
+          .from('user_topic_stats')
+          .select('topic')
+          .lt('accuracy', 70)
+          .eq('user_id', session.user.id)
+
+        if (weakErr) {
+          setError(weakErr.message)
+          setLoading(false)
+          return
+        }
+
+        if (weakTopics && weakTopics.length > 0) {
+          const topics = weakTopics.map((w) => w.topic)
+          questionQuery = questionQuery.in('topic', topics)
+        }
+      }
+
+      const { data, error: fetchError } = await questionQuery
+        .order('created_at', { ascending: false })
+        .limit(20)
 
       if (fetchError) {
         console.error('Error fetching questions', fetchError.message)
         setError(fetchError.message)
       } else if (data) {
-        setQuestions(data as Question[])
+        const processed: Question[] = []
+        for (const q of data as Question[]) {
+          const estimated = estimateDifficulty(q.question_text)
+          processed.push({ ...q, difficulty: estimated })
+          if (q.difficulty !== estimated) {
+            supabase.from('questions').update({ difficulty: estimated }).eq('id', q.id)
+          }
+        }
+        // randomize and limit to 10
+        for (let i = processed.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1))
+          ;[processed[i], processed[j]] = [processed[j], processed[i]]
+        }
+        setQuestions(processed.slice(0, 10))
         setError('')
       }
       setLoading(false)
     }
 
     loadQuestions()
-  }, [session])
+  }, [session, difficultyFilter, searchParams.toString()])
 
   const handleSelect = (id: string, option: string) => {
     if (!isSubmitted) {
@@ -69,7 +113,7 @@ export default function QuizPage() {
     }
   }
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     const correct = questions.reduce((acc, q) => {
       const selectedAnswer = answers[q.id]
       return selectedAnswer?.toUpperCase() === q.correct_option?.toUpperCase()
@@ -77,6 +121,32 @@ export default function QuizPage() {
         : acc
     }, 0)
     setScore(correct)
+
+    const stats: Record<string, { attempted: number; correct: number }> = {}
+    questions.forEach((q) => {
+      const chosen = answers[q.id]
+      const isCorrect = chosen?.toUpperCase() === q.correct_option?.toUpperCase()
+      if (!stats[q.topic]) {
+        stats[q.topic] = { attempted: 0, correct: 0 }
+      }
+      stats[q.topic].attempted += 1
+      if (isCorrect) stats[q.topic].correct += 1
+    })
+
+    for (const topic of Object.keys(stats)) {
+      const s = stats[topic]
+      const accuracy = s.attempted > 0 ? Math.round((s.correct / s.attempted) * 100) : 0
+      await supabase
+        .from('user_topic_stats')
+        .upsert({
+          user_id: session!.user.id,
+          topic,
+          attempted: s.attempted,
+          correct: s.correct,
+          accuracy,
+        })
+    }
+
     setIsSubmitted(true)
   }
 
@@ -89,7 +159,22 @@ export default function QuizPage() {
       <p>You must be logged in to take a quiz.</p>
     ) : (
       <main className="p-4 space-y-4">
-        <h1 className="text-lg font-semibold">Quiz</h1>
+        <h1 className="text-lg font-semibold">
+          {searchParams.get('personalized') === 'true' ? 'Personalized Quiz' : 'Quiz'}
+        </h1>
+        <div>
+          <label className="mr-2">Difficulty:</label>
+          <select
+            className="border px-2 py-1 rounded"
+            value={difficultyFilter}
+            onChange={(e) => setDifficultyFilter(e.target.value as 'All' | Difficulty)}
+          >
+            <option value="All">All</option>
+            <option value="easy">Easy</option>
+            <option value="moderate">Moderate</option>
+            <option value="hard">Hard</option>
+          </select>
+        </div>
         {error && <p className="text-red-600">{error}</p>}
         {loading && <p>Loading questions...</p>}
         {!loading && questions.length === 0 && (

--- a/supabase/migrations/202405241200_create_user_topic_stats.sql
+++ b/supabase/migrations/202405241200_create_user_topic_stats.sql
@@ -1,0 +1,16 @@
+-- SQL migration for user_topic_stats table
+create table if not exists public.user_topic_stats (
+  user_id uuid references auth.users(id) on delete cascade,
+  topic text not null,
+  attempted int not null default 0,
+  correct int not null default 0,
+  accuracy numeric,
+  primary key (user_id, topic)
+);
+
+alter table public.user_topic_stats enable row level security;
+
+create policy "Allow user update" on public.user_topic_stats
+  for all to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);

--- a/utils/estimateDifficulty.ts
+++ b/utils/estimateDifficulty.ts
@@ -1,0 +1,8 @@
+export type Difficulty = 'easy' | 'moderate' | 'hard'
+
+export function estimateDifficulty(questionText: string): Difficulty {
+  const wordCount = questionText.trim().split(/\s+/).filter(Boolean).length
+  if (wordCount < 10) return 'easy'
+  if (wordCount <= 20) return 'moderate'
+  return 'hard'
+}


### PR DESCRIPTION
## Summary
- create `estimateDifficulty` helper
- add `user_topic_stats` migration
- filter quiz by difficulty and show personalized quizzes
- track accuracy by topic and update Supabase
- allow dashboard to start quiz targeting weak areas

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436166a6b8832c9f18310c3e9d8781