### PR TITLE
Add difficulty assignment script

### DIFF
--- a/scripts/assignDifficulty.ts
+++ b/scripts/assignDifficulty.ts
@@ -1,0 +1,37 @@
+import { supabase } from '../lib/supabaseClient'
+import { estimateDifficulty } from '../utils/estimateDifficulty'
+
+async function assignDifficulty() {
+  const { data: questions, error } = await supabase
+    .from('questions')
+    .select('id, question_text, difficulty')
+    .is('difficulty', null)
+
+  if (error) {
+    console.error('Failed to fetch questions:', error)
+    return
+  }
+
+  if (!questions) {
+    console.log('No questions found.')
+    return
+  }
+
+  for (const q of questions) {
+    const difficulty = estimateDifficulty(q.question_text)
+    const { error: updateError } = await supabase
+      .from('questions')
+      .update({ difficulty })
+      .eq('id', q.id)
+
+    if (updateError) {
+      console.error(`Failed to update question ${q.id}:`, updateError)
+    } else {
+      console.log(`Updated question ${q.id} → ${difficulty}`)
+    }
+  }
+}
+
+assignDifficulty().then(() => {
+  console.log('Done')
+})


### PR DESCRIPTION
## Summary
- implement `assignDifficulty.ts` script to set difficulty levels for questions

## Testing
- `npm run lint` *(fails: Next.js missing)*

------
https://chatgpt.com/codex/tasks/task_e_6843936cc60c832cb14aa1597262724c