### PR TITLE
Implement weak topics quiz API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "qbank-platform",
       "version": "0.1.0",
       "dependencies": {
+        "@supabase/auth-helpers-nextjs": "^0.5.9",
         "@supabase/auth-helpers-react": "^0.5.0",
         "@supabase/supabase-js": "^2.49.9",
         "dotenv": "^16.5.0",
@@ -572,6 +573,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.5.9.tgz",
+      "integrity": "sha512-OBmltVuPNFbtznBAgQgOFaWh3dO6rRmU7i77TVzEkbViZoK2ylzlKPIORg9Wh+4ZgYbP2QMsI5GzEtAz+aNTvA==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.3.3"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.0.4"
+      }
+    },
     "node_modules/@supabase/auth-helpers-react": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-react/-/auth-helpers-react-0.5.0.tgz",
@@ -580,6 +594,19 @@
       "license": "MIT",
       "peerDependencies": {
         "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.3.3.tgz",
+      "integrity": "sha512-ZwZGffApfyz9MiT3knnZoF1DMWE56H/Q0Mrsn22J9ubhss7/+e7TP3dChxxwlUYqtDmjmLV6OV8W0BANENfUew==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.0.4"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -3521,6 +3548,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
+      "integrity": "sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@supabase/auth-helpers-nextjs": "^0.5.9",
     "@supabase/auth-helpers-react": "^0.5.0",
     "@supabase/supabase-js": "^2.49.9",
     "dotenv": "^16.5.0",

--- a/src/app/api/quiz/weak-topics/route.ts
+++ b/src/app/api/quiz/weak-topics/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
+
+export async function POST() {
+  const supabase = createRouteHandlerClient({ cookies })
+
+  const {
+    data: { user },
+    error: userError,
+  } = await supabase.auth.getUser()
+
+  if (userError || !user) {
+    return NextResponse.json(
+      { error: 'Unauthorized' },
+      { status: 401 }
+    )
+  }
+
+  const { data: perfData, error: perfError } = await supabase
+    .from('user_performance')
+    .select('tag, accuracy')
+    .eq('user_id', user.id)
+    .order('accuracy', { ascending: true })
+    .limit(3)
+
+  if (perfError || !perfData || perfData.length === 0) {
+    return NextResponse.json(
+      { error: 'No weak topics found' },
+      { status: 404 }
+    )
+  }
+
+  const tags = perfData.map((row) => row.tag)
+
+  const { data: questionData, error: questionError } = await supabase
+    .from('questions')
+    .select('*')
+    .in('tag', tags)
+    .limit(50)
+
+  if (questionError || !questionData || questionData.length === 0) {
+    return NextResponse.json(
+      { error: 'No questions found for weak topics' },
+      { status: 404 }
+    )
+  }
+
+  const shuffled = questionData.sort(() => Math.random() - 0.5)
+  const selected = shuffled.slice(0, Math.min(15, questionData.length))
+
+  if (selected.length < 10) {
+    return NextResponse.json(
+      { error: 'Not enough questions available' },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json({ questions: selected })
+}


### PR DESCRIPTION
## Summary
- install `@supabase/auth-helpers-nextjs`
- add POST endpoint `/api/quiz/weak-topics` to build quizzes from weakest topics

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6843b498d344832c89f101cffd3e9130